### PR TITLE
Change to coal recipe, more recipes for benches

### DIFF
--- a/1.3/Defs/Recipes_Charcoal.xml
+++ b/1.3/Defs/Recipes_Charcoal.xml
@@ -35,6 +35,7 @@
     <jobString>Smelting stone into coal.</jobString>
     <effectWorking>Cremate</effectWorking>
     <soundWorking>Recipe_Cremate</soundWorking>
+    <allowMixingIngredients>true</allowMixingIngredients>
     <workAmount>2800</workAmount>
     <workSpeedStat>GeneralLaborSpeed</workSpeedStat>
     <ingredients>

--- a/1.3/Patches/CoalPatch.xml
+++ b/1.3/Patches/CoalPatch.xml
@@ -100,6 +100,11 @@
 			</li>
 			<li Class="PatchOperationAdd">
 				<success>Always</success>
+				<xpath>/Defs/ThingDef/recipeMaker/recipeUsers[li="FueledStove"]</xpath>
+				<value><li>CoalGrill</li></value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<success>Always</success>
 				<xpath>/Defs/RecipeDef/recipeUsers[li="ElectricSmelter"]</xpath>
 				<value><li>CoalSmelter</li></value>
 			</li>

--- a/1.3/Patches/CoalPatch.xml
+++ b/1.3/Patches/CoalPatch.xml
@@ -90,4 +90,19 @@
       </operations>
     </match>
   </Operation>
+  <!-- Catch a bunch of recipes for the workbenches -->
+  <!-- Catch a bunch of recipes for the workbenches -->
+    <!-- Catch a bunch of recipes for the workbenches -->
+	<Operation Class="PatchOperationSequence">
+		<operations>
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/RecipeDef/recipeUsers[li="FueledStove"]</xpath>
+				<value><li>CoalGrill</li></value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>/Defs/RecipeDef/recipeUsers[li="ElectricSmelter"]</xpath>
+				<value><li>CoalSmelter</li></value>
+			</li>
+		</operations>
+	</Operation>
 </Patch>

--- a/1.3/Patches/CoalPatch.xml
+++ b/1.3/Patches/CoalPatch.xml
@@ -91,8 +91,6 @@
     </match>
   </Operation>
   <!-- Catch a bunch of recipes for the workbenches -->
-  <!-- Catch a bunch of recipes for the workbenches -->
-    <!-- Catch a bunch of recipes for the workbenches -->
 	<Operation Class="PatchOperationSequence">
 		<operations>
 			<li Class="PatchOperationAdd">

--- a/1.3/Patches/CoalPatch.xml
+++ b/1.3/Patches/CoalPatch.xml
@@ -94,10 +94,12 @@
 	<Operation Class="PatchOperationSequence">
 		<operations>
 			<li Class="PatchOperationAdd">
+				<success>Always</success>
 				<xpath>/Defs/RecipeDef/recipeUsers[li="FueledStove"]</xpath>
 				<value><li>CoalGrill</li></value>
 			</li>
 			<li Class="PatchOperationAdd">
+				<success>Always</success>
 				<xpath>/Defs/RecipeDef/recipeUsers[li="ElectricSmelter"]</xpath>
 				<value><li>CoalSmelter</li></value>
 			</li>


### PR DESCRIPTION
Added allowMixingIngredients to Smelting stone into coal recipe, to use up small amounts of blocks lying around from ruins or meteors.

Added two patches to catch more recipes for the cook benches.